### PR TITLE
Add fastjet variant of coffea-base

### DIFF
--- a/.github/workflows/gh-cd.yml
+++ b/.github/workflows/gh-cd.yml
@@ -38,15 +38,17 @@ jobs:
     - name: Push image
       run: |
         VERSION=$(docker run temp-image python -c "import coffea; print(coffea.__version__)")
+        FASTJET_VERSION=$(docker run temp-image python -c "import fastjet; print(fastjet.__version__)")
 
         echo VERSION=$VERSION
+        echo FASTJET_VERSION=$FASTJET_VERSION
 
-        docker tag temp-image ${IMAGE_ID}:$VERSION
-        docker push ${IMAGE_ID}:$VERSION
+        docker tag temp-image ${IMAGE_ID}:$VERSION-fastjet-${FASTJET_VERSION}
+        docker push ${IMAGE_ID}:$VERSION-fastjet-${FASTJET_VERSION}
 
         docker tag temp-image ${IMAGE_ID}:latest
         docker push ${IMAGE_ID}:latest
-        echo "image_tag=${IMAGE_ID}:$VERSION" >> $GITHUB_ENV
+        echo "image_tag=${IMAGE_ID}:$VERSION-fastjet-${FASTJET_VERSION}" >> $GITHUB_ENV
 
     - name: Send dispatch event downstream
       uses: peter-evans/repository-dispatch@v1

--- a/.github/workflows/watch-fastjet-pypi.yml
+++ b/.github/workflows/watch-fastjet-pypi.yml
@@ -1,0 +1,36 @@
+name: Check for new versions of fastjet on PyPI
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    if: github.repository == 'coffeateam/docker-coffea-base'
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Get latest fastjet and update fastjet dockerfile
+        run: |
+          export FASTJET_VERSION=$(python check_pypi.py fastjet | tail -1)
+          echo "FASTJET_VERSION=$FASTJET_VERSION" >> $GITHUB_ENV
+          echo found fastjet version $FASTJET_VERSION from PyPI
+          sed -i "s/\"fastjet==.*\"/\"fastjet==$FASTJET_VERSION\"/g" base/Dockerfile
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update fastjet version to ${{ env.FASTJET_VERSION }}"
+          title: "Update fastjet version to ${{ env.FASTJET_VERSION }}"
+          reviewers: "oshadura"
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          branch: "upgrade-fastjet-version"
+          body: |
+            A new fastjet version has been detected.
+
+            Updated fastjet specializations to use `${{ env.FASTJET_VERSION }}`.

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -32,12 +32,10 @@ RUN conda install --yes --freeze-installed \
       xrootd==5.2.0 \
       "uproot>=4.0.8" \
       coffea==0.7.5 \
+      vector \
       lz4 python-xxhash zstandard \
       && conda clean --all -f -y \
       && conda build purge-all
-
-# add vector
-RUN pip install --no-cache-dir vector
 
 # This is very delicate but it keeps the image size reasonable...
 COPY --from=builder /artifacts /opt/conda/lib/python3.8/site-packages

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,3 +1,19 @@
+FROM continuumio/miniconda3:latest as builder
+
+RUN apt-get update \
+     && apt-get install -yq --no-install-recommends build-essential autoconf automake libtool git g++ gfortran swig libmpfr-dev libboost-dev \
+     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN conda install --yes --freeze-installed -c conda-forge conda-build python==3.8.* \
+     && conda clean --all -f -y \
+     && conda build purge-all
+
+RUN pip install "fastjet==3.3.4.0rc5" -v
+
+RUN mkdir -p /artifacts \
+     && cp -rp $(python -c 'import fastjet; import pathlib; print(pathlib.Path(fastjet.__file__).parent)')* /artifacts \
+     && ls /artifacts
+
 FROM continuumio/miniconda3:latest
 
 RUN apt-get update \
@@ -19,6 +35,12 @@ RUN conda install --yes --freeze-installed \
       lz4 python-xxhash zstandard \
       && conda clean --all -f -y \
       && conda build purge-all
+
+# add vector
+RUN pip install --no-cache-dir vector
+
+# This is very delicate but it keeps the image size reasonable...
+COPY --from=builder /artifacts /opt/conda/lib/python3.8/site-packages
 
 # Make a symbolic link between installation /opt/conda/etc/grid-security and actual directory /etc/grid-security
 RUN ln -s /opt/conda/etc/grid-security /etc/grid-security

--- a/check_pypi.py
+++ b/check_pypi.py
@@ -1,0 +1,18 @@
+import json
+import requests
+from packaging import version
+import argparse
+
+parser = argparse.ArgumentParser("Get the available PyPI versions for a package!")
+parser.add_argument("package", help="The name of the PyPI package.")
+
+
+def versions(package_name):
+    url = f"https://pypi.org/pypi/{package_name}/json"
+    data = json.loads(requests.get(url).text)
+    versions = sorted([v for v in data["releases"].keys()], key=lambda x: version.parse(x))
+    return versions
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    print("\n".join(versions(args.package)))


### PR DESCRIPTION
This is a temporary solution until the fastjet package is building proper wheels.
No cc7 yet.

I would like the image name format to be `coffeateam/coffea-base:fastjet-$FASTJET_VERSION` but I haven't put that together yet completely, would appreciate some help finishing that off in a nice way.

Cleanups and other suggestions welcome.