### PR TITLE
Add xgboost to coffea-base

### DIFF
--- a/base-cc7/Dockerfile
+++ b/base-cc7/Dockerfile
@@ -22,7 +22,7 @@ RUN conda install --yes --freeze-installed \
       xrootd==5.2.0 \
       "uproot>=4.0.8" \
       coffea==0.7.6 \
-      vector \
+      vector xgboost \
       lz4 python-xxhash zstandard \
      && conda clean --all -f -y \
      && conda build purge-all \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -16,7 +16,7 @@ RUN conda install --yes --freeze-installed \
       xrootd==5.2.0 \
       "uproot>=4.0.8" \
       coffea==0.7.6 \
-      vector \
+      vector xgboost \
       lz4 python-xxhash zstandard \
      && conda clean --all -f -y \
      && conda build purge-all \


### PR DESCRIPTION
Reasons:
* BDTs are very common in HEP analysis
* the baseline `pip install xgboost` is 500 MB due to default GPU support
* the conda install does not have GPU support and is 5-6MB
* `pip install --no-binary :all: xgboost` doesn't work from within container (missing build tools)

Minimal image-size impact with large gains for container usability.