### PR TITLE
Update Coffea version to 0.7.22

### DIFF
--- a/.github/workflows/gh-ci.yml
+++ b/.github/workflows/gh-ci.yml
@@ -12,7 +12,7 @@ env:
   DOCKER_ORG: coffeateam
   GITHUB_SHA: ${{ github.sha }}
   GITHUB_REF: ${{ github.ref }}
-  release: "0.7.21"
+  release: "0.7.22"
 
 jobs:
 


### PR DESCRIPTION
A new Coffea version has been detected.

Updated `Dockerfile`s to use `0.7.22`.