### PR TITLE
Add zsh to base images

### DIFF
--- a/base-almalinux8/Dockerfile
+++ b/base-almalinux8/Dockerfile
@@ -6,7 +6,7 @@ ARG release
 ENV PYTHON_VERSION=${python}
 
 RUN yum -y update \
-     && yum -y install git curl bzip2 libgfortran which \
+     && yum -y install git curl bzip2 libgfortran which zsh \
      && curl -sSL https://github.com/conda-forge/miniforge/releases/download/23.3.1-1/Mambaforge-Linux-x86_64.sh -o /tmp/mambaforge.sh \
      && bash /tmp/mambaforge.sh -bfp /usr/local \
      && rm -rf /tmp/mambaforge.sh \

--- a/base-cc7/Dockerfile
+++ b/base-cc7/Dockerfile
@@ -6,7 +6,7 @@ ARG release
 ENV PYTHON_VERSION=${python}
 
 RUN yum -y update \
-     && yum -y install git curl bzip2 libgfortran which \
+     && yum -y install git curl bzip2 libgfortran which zsh \
      && curl -sSL https://github.com/conda-forge/miniforge/releases/download/23.3.1-1/Mambaforge-Linux-x86_64.sh -o /tmp/mambaforge.sh \
      && bash /tmp/mambaforge.sh -bfp /usr/local \
      && rm -rf /tmp/mambaforge.sh \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND="noninteractive"
 ENV TZ="Etc/UTC"
 
 RUN apt-get update \
-     && apt-get install -yq --no-install-recommends libarchive-dev \
+     && apt-get install -yq --no-install-recommends libarchive-dev zsh \
      && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # XRootD + CA + VOMS + Coffea


### PR DESCRIPTION
This PR adds zsh to base images (no oh-my-zsh), for those of us on the dark side. Recipes were tested locally on an M1 Mac (note: linux builds required e.g. ```FROM --platform=linux/amd64 almalinux:8``` 

tcsh is apparently the next most popular shell amongst HEP folks, if a little bit of scope creep were considered

Optional adds? oh-my-zsh, an opinionated .zshrc, ...

